### PR TITLE
add tabAlignment

### DIFF
--- a/lib/src/scrollable_tab_bar.dart
+++ b/lib/src/scrollable_tab_bar.dart
@@ -50,6 +50,7 @@ class ScrollableTabBar extends StatelessWidget {
   final ScrollPhysics? physics;
   final InteractiveInkFeatureFactory? splashFactory;
   final BorderRadius? splashBorderRadius;
+  final TabAlignment? tabAlignment;
   const ScrollableTabBar({
     Key? key,
     required this.tabs,
@@ -75,6 +76,7 @@ class ScrollableTabBar extends StatelessWidget {
     this.physics,
     this.splashFactory,
     this.splashBorderRadius,
+    this.tabAlignment,
   }) : super(key: key);
 
   @override
@@ -104,6 +106,7 @@ class ScrollableTabBar extends StatelessWidget {
       splashFactory: splashFactory,
       unselectedLabelColor: unselectedLabelColor,
       unselectedLabelStyle: unselectedLabelStyle,
+      tabAlignment: tabAlignment,
     );
   }
 }


### PR DESCRIPTION
Hi

I got this problem, when I use isScrollable of ScrollableTabBar
https://stackoverflow.com/questions/77601730/left-padding-error-in-tabbar-flutter-widget

So, I added tabAlignment for solving this problem.

Thanks for your nice package!